### PR TITLE
fix: set after only in header items

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "iq-blueberry",
-	"version": "0.0.36",
+	"version": "0.0.37",
 	"description": "iq design system/ui library",
 	"main": "dist/main.js",
 	"module": "es/main.js",

--- a/src/core/components/Header.styl
+++ b/src/core/components/Header.styl
@@ -228,7 +228,7 @@ $header-desk-height = 70px
 			font-size 14px
 			padding 10px 15px
 
-			:not(&--submenu)::after
+			&:not(&--submenu)::after
 				content: '';
 				position: absolute;
 				bottom: 0;


### PR DESCRIPTION
After blueberry update, all elements had an after selector badly injected by header element.  
To fix it:
- Set ::after element to header scope