### PR TITLE
[IQL-9356] footer | feat: :lipstick: font color on footer updated to improve accessibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "iq-blueberry",
-	"version": "0.0.47",
+	"version": "0.0.48",
 	"description": "iq design system/ui library",
 	"main": "dist/main.js",
 	"module": "es/main.js",

--- a/src/core/components/legacy/FooterClassic.styl
+++ b/src/core/components/legacy/FooterClassic.styl
@@ -242,7 +242,7 @@
 		text-align center
 
 		&--copy
-			color #919191
+			color gray-60
 
 		&--contact
 			margin-top 32px


### PR DESCRIPTION
We had an error on axe monitor about colors without enough contrast, which was bad for the accessibility.

The font color is now #444 (gray-60)

![image](https://user-images.githubusercontent.com/7524162/233109256-5db29a27-501b-4bf5-b44e-83e8a93bc900.png)
