### PR TITLE
feat: toggle error icon on input

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "iq-blueberry",
-	"version": "0.0.64",
+	"version": "0.0.65",
 	"description": "iq design system/ui library",
 	"main": "dist/main.js",
 	"module": "es/main.js",

--- a/src/flavors/react/components/form/InputField/index.tsx
+++ b/src/flavors/react/components/form/InputField/index.tsx
@@ -20,6 +20,8 @@ interface InputProps extends ModifiedInputProps, CommonFieldsProps {
   useNumericKeyboard?: boolean;
   /** Ref to the input element */
   inputRef?: React.MutableRefObject<any>;
+  /** Hide error alert icon */
+  hideErrorIcon?: boolean
 }
 
 const InputField: React.FC<InputProps> = ({
@@ -41,9 +43,10 @@ const InputField: React.FC<InputProps> = ({
   tooltipConfig,
   useNumericKeyboard = false,
   inputRef,
+  hideErrorIcon,
   ...rest
 }) => {
-  const shouldRenderRightIcon = !invalid && !!Icon;
+  const shouldRenderRightIcon = hideErrorIcon || (!invalid && !!Icon)
 
   function onChangeHandler(e) {
     if (!!onChange) {
@@ -92,10 +95,14 @@ const InputField: React.FC<InputProps> = ({
             {...rest}
           />
           <div className="iq-input-field__icon iq-input-field__icon--right">
-            <div className="iq-input-field__invalid-icon">
-              <IconFilledError expand />
-            </div>
-            {!!shouldRenderRightIcon ? <Icon expand /> : null}
+
+            {hideErrorIcon ? null :
+              (<div className="iq-input-field__invalid-icon">
+                <IconFilledError expand />
+              </div>)
+            }
+
+            {shouldRenderRightIcon ? <Icon expand /> : null}
           </div>
         </div>
       </FieldBase>

--- a/src/flavors/react/components/form/PasswordField/index.tsx
+++ b/src/flavors/react/components/form/PasswordField/index.tsx
@@ -8,10 +8,12 @@ import { TooltipProps } from "../../Tooltip";
 interface PasswordProps extends ModifiedInputProps, CommonFieldsProps {
   showEye?: boolean;
   tooltipConfig?: TooltipProps;
+  hideErrorIcon?: boolean
 }
 
 const PasswordField: React.FC<PasswordProps> = ({
   showEye = true,
+  hideErrorIcon,
   ...props
 }) => {
   const [isShowingPassword, setIsShowingPassword] = useState(false);
@@ -37,6 +39,7 @@ const PasswordField: React.FC<PasswordProps> = ({
       customClass="iq-password-field"
       htmlType={fieldType}
       Icon={Icon}
+      hideErrorIcon={hideErrorIcon}
       {...props}
     />
   );


### PR DESCRIPTION
This PRs adds the possibility to hide error icon on invalid field

### Use Example

**Regular field**

![image](https://github.com/IQ-tech/blueberry/assets/55505983/7331ea45-d8c4-43d4-8b05-c9610a5801bf)

**When field is invalid we change the icon and user cant click on eye to see what's wrong with the password**

![image](https://github.com/IQ-tech/blueberry/assets/55505983/fe54afe9-3e41-4de3-ae44-342c998ea707)

**Using the new prop on PasswordInput component (or directly on Input component) we can keep the original icon when field is invalid**

![image](https://github.com/IQ-tech/blueberry/assets/55505983/ac1ff9fc-4898-4ffa-8cb4-2d191333a4d4)
![image](https://github.com/IQ-tech/blueberry/assets/55505983/621ffc8f-bcb4-4bcd-85b3-41c697ce57e2)

