### PR TITLE
[GTW-470] TokenFIeld - Backspace behavior

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "iq-blueberry",
-	"version": "0.0.70",
+	"version": "0.0.71",
 	"description": "iq design system/ui library",
 	"main": "dist/main.js",
 	"module": "es/main.js",

--- a/src/flavors/react/components/form/TokenField/hook.ts
+++ b/src/flavors/react/components/form/TokenField/hook.ts
@@ -78,15 +78,19 @@ export default function useTokenInput({
   function onKeyUpHandler(e, i) {
     const hasBackspacePressed = e.which === 8 || e.key === 'Backspace'
     if (hasBackspacePressed) {
-      setTokenMap({ ...tokenMap, [i]: '' })
       const previousItem = rootElementRef.current.querySelector(
         `[data-token-i='${i - 1}']`
       )
-      if (!!previousItem) previousItem.focus()
+      const currentItem = rootElementRef.current.querySelector(
+        `[data-token-i='${i}']`
+      )
+
+      setTokenMap({ ...tokenMap, [i]: '' })
+      if (!!previousItem && !currentItem.value) previousItem.focus()
     }
   }
 
-  function onChangeNumber(e) {
+  function onChangeNumber(e, i) {
     e.preventDefault()
     let value = e?.target?.value
     const isNumberValid = inputtedValueIsValid(value)
@@ -102,7 +106,14 @@ export default function useTokenInput({
         value = value[value.length - 1]
       }
 
-      if (firstEmptyIndex < 0) return
+      if (firstEmptyIndex < 0 ) {
+
+        if (!!value) {
+          setTokenMap({ ...tokenMap, [i]: value })
+        }
+
+        return
+      }
 
       setTokenMap({ ...tokenMap, [firstEmptyIndex]: value })
       if (!isEmpty) _goToNextInput(firstEmptyIndex)

--- a/src/flavors/react/components/form/TokenField/index.tsx
+++ b/src/flavors/react/components/form/TokenField/index.tsx
@@ -51,7 +51,7 @@ const TokenField = ({
             value={tokenMap[i]}
             disabled={disabled}
             className="iq-input-field__input"
-            onChange={(e) => onChangeNumber(e)}
+            onChange={(e) => onChangeNumber(e, i)}
             onKeyUp={(e) => onKeyUpHandler(e, i)}
             onPaste={(e) => onPasteNumber(e)}
             data-token-i={i}


### PR DESCRIPTION
This PR changes the TokenField behavior when backspace is pressed.

Before:
- The field was emptied and the focus changed to the previous field. When the user pressed a new digit, it replaced the current number.

Now:
- The field is emptied but the focus remains on the current field, so when the user press a new digit, it will fill the field that was emptied.
- If the user presses backspace in an empty field, the focus is changed to the previous field.