### PR TITLE
Fix/eye passwordfield

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "iq-blueberry",
-	"version": "0.0.82",
+	"version": "0.0.83",
 	"description": "iq design system/ui library",
 	"main": "dist/main.js",
 	"module": "es/main.js",

--- a/src/flavors/react/components/form/InputField/index.tsx
+++ b/src/flavors/react/components/form/InputField/index.tsx
@@ -50,6 +50,7 @@ const InputField: React.FC<InputProps> = ({
   checkCapsLock = false,
   ...rest
 }) => {
+  const capsLockDefaultMessage = "O botão Caps Lock está ativo."
   const shouldRenderRightIcon = hideErrorIcon || (!invalid && !!Icon)
 
   const [isCapsLockOn, setCapsLockState] = useState(false);
@@ -118,7 +119,7 @@ const InputField: React.FC<InputProps> = ({
             {shouldRenderRightIcon ? <Icon expand /> : null}
           </div>
         </div>
-        {(isCapsLockOn && checkCapsLock) && <p className="iq-input-field__caps-lock-activated">{capsLockMessage || "o botão Caps Lock está ativo."}</p>}
+        {(isCapsLockOn && checkCapsLock) && <p className="iq-input-field__caps-lock-activated">{capsLockMessage || capsLockDefaultMessage}</p>}
       </FieldBase>
     </div>
   );

--- a/src/flavors/react/components/form/InputField/index.tsx
+++ b/src/flavors/react/components/form/InputField/index.tsx
@@ -107,7 +107,6 @@ const InputField: React.FC<InputProps> = ({
             onKeyUp={handleKeyPress}
             {...rest}
           />
-          {(isCapsLockOn && checkCapsLock) && <p className="iq-input-field__caps-lock-activated">{capsLockMessage || "o botão Caps Lock está ativo."}</p>}
           <div className="iq-input-field__icon iq-input-field__icon--right">
 
             {hideErrorIcon ? null :
@@ -119,6 +118,7 @@ const InputField: React.FC<InputProps> = ({
             {shouldRenderRightIcon ? <Icon expand /> : null}
           </div>
         </div>
+        {(isCapsLockOn && checkCapsLock) && <p className="iq-input-field__caps-lock-activated">{capsLockMessage || "o botão Caps Lock está ativo."}</p>}
       </FieldBase>
     </div>
   );


### PR DESCRIPTION
**Bug**: Ajuste no posicionamento do texto de alerta de Caps Lock ativo

O texto estava interferindo no posicionamento do ícone a direita do campo, como mostrado abaixo: 

<img width="725" alt="Captura de ecrã 2024-06-13, às 10 27 05" src="https://github.com/IQ-tech/blueberry/assets/121800136/32cb2b64-a17d-4e64-aa00-5c89f60110f6">


Correção: 
<img width="749" alt="Captura de ecrã 2024-06-13, às 10 27 56" src="https://github.com/IQ-tech/blueberry/assets/121800136/8e66e188-a52f-4fbd-8217-a8024b6770db">


